### PR TITLE
Add type "a" to FSUIPC Offset variables for byte[]

### DIFF
--- a/Plugin/Resources/Scripts/ManagedScript.cs
+++ b/Plugin/Resources/Scripts/ManagedScript.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 
 namespace PilotsDeck.Resources.Scripts
@@ -287,9 +288,17 @@ namespace PilotsDeck.Resources.Scripts
                 return SimWrite(name, numValue);
             else if (value is string)
                 return SimWrite(name, value as string);
+            else if (value is LuaTable)
+                return SimWrite(name, value as LuaTable);
             else
                 return SimWrite(name, value.ToString());
         }
+
+        protected virtual bool SimWrite(string name, LuaTable value)
+        {
+            return SimWrite(name, "[" + string.Join(",", value.ArrayList.Select(v => v.ToString())) + "]");
+        }
+
 
         protected virtual bool SimWrite(string name, double value)
         {

--- a/Plugin/Resources/Variables/OffsetParam.cs
+++ b/Plugin/Resources/Variables/OffsetParam.cs
@@ -7,7 +7,8 @@ namespace PilotsDeck.Resources.Variables
         INTEGER,
         FLOAT,
         STRING,
-        BIT
+        BIT,
+        BYTEARRAY
     }
 
     public class OffsetParam
@@ -46,6 +47,9 @@ namespace PilotsDeck.Resources.Variables
                     case "b":
                         Type = OffsetType.BIT;
                         BitNum = 0;
+                        break;
+                    case "a":
+                        Type = OffsetType.BYTEARRAY;
                         break;
                     default:
                         Type = OffsetType.INTEGER;

--- a/Plugin/Resources/Variables/VariableOffset.cs
+++ b/Plugin/Resources/Variables/VariableOffset.cs
@@ -280,6 +280,20 @@ namespace PilotsDeck.Resources.Variables
                             return newValue;
                     }
                 }
+                else if (IsByteArray)
+                {
+                    if (newValue.StartsWith("0x"))
+                        return Convert.FromHexString(newValue[2..]);
+                    if (newValue.Length > 2 && newValue[0] == '[' && newValue[^1] == ']')
+                        return newValue.Trim('[', ']').Split(',').SelectMany(part =>
+                        {
+                            if (part.StartsWith("0x"))
+                                return Convert.FromHexString(part[2..]);
+                            return [byte.Parse(part)];
+                        }).ToArray();
+                    else
+                        return BitConverter.GetBytes(long.Parse(newValue));
+                }
                 else
                 {
                     switch (Size)

--- a/Plugin/Resources/Variables/VariableOffset.cs
+++ b/Plugin/Resources/Variables/VariableOffset.cs
@@ -2,6 +2,7 @@
 using PilotsDeck.Tools;
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace PilotsDeck.Resources.Variables
 {
@@ -14,6 +15,7 @@ namespace PilotsDeck.Resources.Variables
         public bool IsString { get { return OffsetParam.Type == OffsetType.STRING; } }
         public bool IsFloat { get { return OffsetParam.Type == OffsetType.FLOAT; } }
         public bool IsBit { get { return OffsetParam.Type == OffsetType.BIT; } }
+        public bool IsByteArray { get { return OffsetParam.Type == OffsetType.BYTEARRAY; } }
 
         public override string Value { get { return Read(); } }
         protected virtual string ValueLast { get; set; } = "";
@@ -96,6 +98,8 @@ namespace PilotsDeck.Resources.Variables
         {
             if (IsString)
                 return ReadOffsetString();
+            if (IsByteArray)
+                return $"[{string.Join(",", ReadByteArray().Select(b => Convert.ToString(b)))}]";
             else //should be float, int or bit
             {
                 var result = ReadNumber();
@@ -118,8 +122,23 @@ namespace PilotsDeck.Resources.Variables
         {
             if (IsString)
                 return ReadOffsetString();
+            if (IsByteArray)
+                return ReadByteArray();
             else //should be float, int or bit
                 return ReadNumber();
+        }
+
+        protected byte[] ReadByteArray()
+        {
+            try
+            {
+                return IpcOffset.GetValue<byte[]>();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException(ex);
+                return Array.Empty<byte>();
+            }
         }
 
         protected string ReadOffsetString()

--- a/Plugin/Tools/TypeMatching.cs
+++ b/Plugin/Tools/TypeMatching.cs
@@ -26,7 +26,7 @@ namespace PilotsDeck.Tools
         public static readonly Regex rxLvar = new($"^((L:|[^:0-9]){{1}}{validLVarName}){{1}}$", RegexOptions.Compiled);
         public static readonly string validHvar = $"((?!K:)(?!B:)(H:|[^:0-9]){{1}}{validName}(:[0-9]+){{0,1}}){{1}}";
         public static readonly Regex rxHvar = new($"^({validHvar}){{1}}(:{validHvar})*$", RegexOptions.Compiled);
-        public static readonly Regex rxOffset = new(@"^((0x){0,1}[0-9A-Fa-f]{4}:[0-9]{1,3}((:[ifs]{1}(:s)?)|(:b:[0-9]{1,2}))?){1}$", RegexOptions.Compiled);
+        public static readonly Regex rxOffset = new(@"^((0x){0,1}[0-9A-Fa-f]{4}:[0-9]{1,4}((:[ifsa]{1}(:s)?)|(:b:[0-9]{1,2}))?){1}$", RegexOptions.Compiled);
         public static readonly Regex rxVjoy = new(@"^(vjoy:|vJoy:|VJOY:){0,1}(6[4-9]|7[0-2]){1}:(0?[0-9]|1[0-9]|2[0-9]|3[0-1]){1}(:t)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static readonly Regex rxVjoyDrv = new(@"^(vjoy:|vJoy:|VJOY:){0,1}(1[0-6]|[0-9]){1}:([0-9]|[0-9]{2}|1[0-1][0-9]|12[0-8]){1}(:t)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static readonly Regex rxDref = new($"^({validNameXP}[\\x2F]){{1}}({validNameMultipleXP}[\\x2F])*({validNameMultipleXP}(([\\x5B][0-9]+[\\x5D])|(:s[0-9]+)){{0,1}}){{1}}$", RegexOptions.Compiled);

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Another great Source for L-Vars and (other Stuff) is [HubHop](https://hubhop.mob
 | --- | --- | --- |
 - *Address*: The Address of the FSUIPC Offset as 4-Digit Hexadecimal Number, as documented in FSUIPC. The Hex Prefix `0x` is Optional.
 - *Size*: The Size of this Offset in Bytes. A 1-digit (Decimal) Number.
-- *Type*: Specify if the Offset is an Integer `i`, Float/Double `f`, Bit `b` or String `s`. Defaults to `:i` if not specified.
+- *Type*: Specify if the Offset is an Integer `i`, Float/Double `f`, Bit `b`, String `s` or Byte Array `a`. Defaults to `:i` if not specified.
 - *Signedness*: Specify if the Offset is Signed `s` or Unsigned `u`. Defaults to `:u` if not specified (only relevant for Integers).
 - *BitNum*: Only for Offset-Type Bit, the Number/Index of the Bit to read from or write to.
 
@@ -294,6 +294,7 @@ Another great Source for L-Vars and (other Stuff) is [HubHop](https://hubhop.mob
 - `0x0ec6:2:i` - Read a *2* Byte long *unsigned* *integer* Number from Address *0EC6* ("Pressure QNH").
 - `0x5408:10:s` - Read a *10* Byte long *String* from Address *5408*.
 - `0x0D0C:2:b:1` - Read Bit *1* from the *2* Byte long Bitmask at Address *0D0C* (Nav Lights).
+- `0x5800:1024:a` - Read a *1024* byte array from Address *5800* (Reads the right CDU screen contents on PMDG aircraft)
 
 Before you use an Offset as **Command**, make sure that it is writeable (some are read-only)! When used as Command, you need to specify the **On Value** and the **Off Value**. The Plugin will toggle between these two Values and writes them to the Variable. Use only 1 or 0 for Bit-Offsets.<br/>
 In addition to writing plain Values, the Plugin can also do simple Operations like increasing/decreasing the Value or toggling the Value in a defined Sequence. Look under [Command Options](#212---command-options) for Details.<br/><br/>

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Another great Source for L-Vars and (other Stuff) is [HubHop](https://hubhop.mob
 - `0x0D0C:2:b:1` - Read Bit *1* from the *2* Byte long Bitmask at Address *0D0C* (Nav Lights).
 - `0x5800:1024:a` - Read a *1024* byte array from Address *5800* (Reads the right CDU screen contents on PMDG aircraft)
 
-Before you use an Offset as **Command**, make sure that it is writeable (some are read-only)! When used as Command, you need to specify the **On Value** and the **Off Value**. The Plugin will toggle between these two Values and writes them to the Variable. Use only 1 or 0 for Bit-Offsets.<br/>
+Before you use an Offset as **Command**, make sure that it is writeable (some are read-only)! When used as Command, you need to specify the **On Value** and the **Off Value**. The Plugin will toggle between these two Values and writes them to the Variable. Use only 1 or 0 for Bit-Offsets. For byte array offsets, you can either specify the new value as a hex string prefixed with `0x` (e.g. `0xdeadbeef`) or a JSON-like array of hex strings (prefixed with `0x`) or decimal numbers (e.g. `[26,0x3f]`).<br/>
 In addition to writing plain Values, the Plugin can also do simple Operations like increasing/decreasing the Value or toggling the Value in a defined Sequence. Look under [Command Options](#212---command-options) for Details.<br/><br/>
 
 *Background*:<br/>


### PR DESCRIPTION
Hi,

I wanted to be able to read the contents of the PMDG 777 CDU units via FSUIPC. In particular, I want to do this to determine if the auto time compression functionality is enabled. In order to do so, it would be very useful to be able to retrieve a `byte[]` from FSUIPC. This PR adds the capability to do that. 

Out of completeness, here is an extract of my global Lua script that I wrote to use the new functionality:
```lua
RunSim("MSFS")
RunAircraft("PMDG 777")
RunInterval(200, "UpdateVariables")

local CDU_COLUMNS = 24
local CDU_ROWS = 14
local AutoCruise = 0

SimVar("0x5800:1024:a")
function UpdateVariables()
    local bytes = SimRead("0x5800:1024:a")
    local rows = {}
    local byteIndex = 0

    for col=1,CDU_COLUMNS do
        for row=1,CDU_ROWS do
            if col == 1 then
                rows[row] = {}
            end
        
            rows[row][col] = { Symbol=string.char(bytes[byteIndex]), Color=bytes[byteIndex+1], Flags=bytes[byteIndex+2] }
            byteIndex = byteIndex + 3
        end
    end

    local title = ""
    for idx, cell in ipairs(rows[1]) do
        if cell.Symbol ~= string.char(0) and cell.Symbol ~= " " then
            title = title .. cell.Symbol
        end
    end

    if title == "AUTOCRUISE" then
        if bit32.extract(rows[9][2].Flags, 0) == 0 then
            AutoCruise = 2
        else
            AutoCruise = 1
        end
    else
        AutoCruise = 0
    end
end

function GetAutoCruise()
    return AutoCruise
end
```

PS. Great work on this project! I find it very useful and use it every flight 😃 