### PR TITLE
Two fixes for X-Plane Web API.

### DIFF
--- a/Plugin/Simulator/XP/ConnectionManagerREST.cs
+++ b/Plugin/Simulator/XP/ConnectionManagerREST.cs
@@ -315,7 +315,7 @@ namespace PilotsDeck.Simulator.XP
                 {
                     foreach (string xpcmd in xpcmds)
                     {
-                        if (WebSocket.HasCommandRef(xpcmd, out long id) && await SendCommandRef(id, command.IsUp))
+                        if (await SendCommandRef(xpcmd, command.IsUp))
                         {
                             success++;
                             if (command.CommandDelay > 0)
@@ -325,7 +325,7 @@ namespace PilotsDeck.Simulator.XP
                 }
                 else if (xpcmds.Length == 1)
                 {
-                    if (WebSocket.HasCommandRef(command.Address.Address, out long id) && await SendCommandRef(id, command.IsUp))
+                    if (await SendCommandRef(command.Address.Address, command.IsUp))
                         success++;
                 }
                 else
@@ -336,9 +336,13 @@ namespace PilotsDeck.Simulator.XP
 
             return success == xpcmds.Length * command.Ticks;
         }
-
-        public virtual async Task<bool> SendCommandRef(long id, bool isUp)
+        public virtual async Task<bool> SendCommandRef(string cmdName, bool isUp)
         {
+            if (await WebSocket.GetCommandRefId(cmdName) is not long id)
+            {
+                return false;
+            }
+
             var message = new SetCommandRefMessage(RequestID++);
             if (!isUp)
             {
@@ -356,7 +360,7 @@ namespace PilotsDeck.Simulator.XP
             }
             
             var cid = message.@params.commands.First().id;
-            Logger.Debug($"Sending Command Request '{message.req_id}': {cid} -> {WebSocket.KnownCommands[cid].name} | {message.@params.commands.First().duration} | {message.@params.commands.First().is_active}");
+            Logger.Debug($"Sending Command Request '{message.req_id}': {cid} -> {cmdName} | {message.@params.commands.First().duration} | {message.@params.commands.First().is_active}");
             OutstandingRequests.Add(message.req_id, OutstandingRequest.Create(message.req_id, message, RequestType.SetCommandActive));
             await WebSocket.SendJsonRequest(message);
             Logger.Debug($"Command sent.");

--- a/Plugin/Simulator/XP/WS/MappingManager.cs
+++ b/Plugin/Simulator/XP/WS/MappingManager.cs
@@ -16,7 +16,6 @@ namespace PilotsDeck.Simulator.XP.WS
         public virtual ConcurrentDictionary<long, List<IdMappingXP>> SubscribedDataIds { get; } = [];
         protected virtual WebSocketXP WebSocket { get; } = socketXP;
         protected virtual ConcurrentDictionary<long, DataRef> KnownDataRefs => WebSocket.KnownDataRefs;
-        protected virtual ConcurrentDictionary<long, CommandRef> KnownCommands => WebSocket.KnownCommands;
         public virtual bool HasDataRefMappings => !SubscribedDataIds.IsEmpty;
 
         public virtual bool HasDataRef(string name, out DataRef dataRef)

--- a/Plugin/Simulator/XP/WS/WebSocketXP.cs
+++ b/Plugin/Simulator/XP/WS/WebSocketXP.cs
@@ -24,7 +24,7 @@ namespace PilotsDeck.Simulator.XP.WS
         protected virtual bool ClientInitialized { get; set; } = false;
         public virtual string RestBaseUrl { get; } = "/api/v2/";
         public virtual ConcurrentDictionary<long, DataRef> KnownDataRefs { get; } = [];
-        public virtual ConcurrentDictionary<long, CommandRef> KnownCommands { get; } = [];
+        protected virtual ConcurrentDictionary<string, CommandRef> KnownCommands { get; } = [];
         public virtual bool HasEnumeratedRefs => !KnownDataRefs.IsEmpty && !KnownCommands.IsEmpty;
 
         public virtual async Task Connect()
@@ -94,7 +94,7 @@ namespace PilotsDeck.Simulator.XP.WS
             Logger.Debug($"Enumerating CommandRefs via Web API ...");
             CommandRefList commandList = await RestGet<CommandRefList>("commands");
             foreach (var command in commandList.data)
-                KnownCommands.Add(command.id, command);
+                KnownCommands.Add(command.name, command);
             Logger.Debug($"Received {KnownCommands.Count} CommandRefs");
         }
 
@@ -104,10 +104,16 @@ namespace PilotsDeck.Simulator.XP.WS
             KnownCommands.Clear();
         }
 
-        protected virtual async Task<T> RestGet<T>(string path) where T : class
+        protected virtual async Task<T> RestGet<T>(string path, (string key, string value)[] parameters = null) where T : class
         {
             T jsonObject = null;
-            HttpResponseMessage response = await RestClient.GetAsync($"{RestBaseUrl}{path}");
+            string Url = $"{RestBaseUrl}{path}";
+            if (parameters != null)
+            {
+                Url += "?" + string.Join("&", parameters.Select(p => Uri.EscapeDataString(p.key) + "=" + Uri.EscapeDataString(p.value)));
+            }
+            HttpResponseMessage response = await RestClient.GetAsync(Url);
+
             if (response.IsSuccessStatusCode)
             {
                 try
@@ -150,20 +156,29 @@ namespace PilotsDeck.Simulator.XP.WS
             return response.IsSuccessStatusCode;
         }
 
-        public virtual bool HasCommandRef(string cmdRef, out long id)
+        public virtual async Task<long?> GetCommandRefId(string cmdName)
         {
-            var query = KnownCommands.Where(kv => kv.Value.name == cmdRef);
-            if (query.Any())
+            if (KnownCommands.TryGetValue(cmdName, out CommandRef cmd))
             {
-                id = query.First().Key;
-                return true;
+                return cmd.id;
             }
-            else
+
+            Logger.Debug($"Querying for CommandRef `{cmdName}` via Web API ...");
+            CommandRefList commandList = await RestGet<CommandRefList>("commands", [("filter[name]", cmdName)] );
+            foreach (var command in commandList.data)
             {
-                Logger.Warning($"No ID found for CommandRef '{cmdRef}'");
-                id = 0;
-                return false;
+                KnownCommands.Add(command.name, command);
+                Logger.Debug($"Received CommandRef '{command}'");
             }
+            Logger.Debug($"Received {commandList.data.Count} CommandRefs");
+
+            if (KnownCommands.TryGetValue(cmdName, out cmd))
+            {
+                return cmd.id;
+            }
+
+            Logger.Warning($"No ID found for CommandRef '{cmdName}'");
+            return null;
         }
 
         public virtual async Task CloseSockets()


### PR DESCRIPTION
*   Fix the logic for setting `SimCommand.IsUp`.

    For "Command Once" commands, this was erroneously not being set to true,
    and as a result, these commands did not work correctly with the Web API.

    "Command Once" commands should result in a Web API
    [`command_set_is_active`](https://developer.x-plane.com/article/x-plane-web-api/#Activate_a_command_v2)
    message with a duration of zero, so that the command is set and
    immediately unset. To send a zero duration, `SimCommand.IsUp` should
    be true (see corresponding code in
    [`ConnectionManagerRest.SendCommandRef`](https://github.com/Fragtality/PilotsDeck/blob/4b8aee4aab8a3a0483936c720f9c0185cd7820f6/Plugin/Simulator/XP/ConnectionManagerREST.cs#L354).

    However, `SimCommand.IsUp` was erroneously being set to false for
    "Command Once" commands, and this resulted in the
    `command_set_is_active` request being sent with a null duration.
    This resulted in the command remaining active indefinitely. The
    command would therefore only have an effect the first time, and
    subsequent attempts to send the command would have no effect.

    Details on the change:

    *   The existing `keyUp!` looks as if it was a typo for `!keyUp`:
        Firstly, `keyUp` is not nullable, so it's not necessary to use
        the null-forgiving operator. Secondly, the case where `keyUp` is
        true is already handled anyway by the `... || keyUp` case. What
        we want to do here instead is to test for `!keyUp`. In other
        words, even if this was not a key-up event, we want to set
        `SimCommand.IsUp` to true.

    *   The existing `!UseXpCommandOnce` had an extraneous `!`. We want
        to set `IsUp` to true for "Command Once" commands, so we should
        simply be testing for `UseXpCommandOnce`.

*   Add code to account for the case where an addon adds commands after
    the initial query to populate `KnownCommands`. In my experience, the
    FlightFactor 757 does this, for example. Trying to send these
    commands would not be successful because they would not be found in
    `KnownCommands`.

    To deal with this, if I don't find the desired command in
    `KnownCommands`, I send another `commands` request to query
    specifically for the desired command, and add it to `KnownCommands`.

    While I'm here, I've changed `KnownCommands` to be indexed by
    command name, rather than command ID. This allows commands to be
    looked up more efficiently using a dictionary lookup, rather than
    having to scan the entire dictionary.

    Rather than changing the definition of `MappingManager.KnownCommands`
    accordingly, I've removed it because it wasn't being used for anything.
