### PR TITLE
Fix the logic for setting `SimCommand.IsUp`.

### DIFF
--- a/Plugin/Actions/Advanced/ActionCommand.cs
+++ b/Plugin/Actions/Advanced/ActionCommand.cs
@@ -125,7 +125,7 @@ namespace PilotsDeck.Actions.Advanced
                 Context = context,
                 Address = Address.Copy(),
                 Type = CommandType,
-                IsUp = (keyUp! && CommandType == SimCommandType.XPCMD && !UseXpCommandOnce) || keyUp,
+                IsUp = (!keyUp && CommandType == SimCommandType.XPCMD && UseXpCommandOnce) || keyUp,
                 Ticks = Math.Abs(ticks),
                 TickDelay = TickDelay,
                 EncoderAction = encoderAction

--- a/Plugin/Actions/Simple/ActionCommand.cs
+++ b/Plugin/Actions/Simple/ActionCommand.cs
@@ -110,7 +110,7 @@ namespace PilotsDeck.Actions.Simple
 
             simCommand.Context = context;
             simCommand.Ticks = isCalcCode || State.IsCode ? 1 : Math.Abs(ticks);
-            simCommand.IsUp = (keyUp! && CommandType == SimCommandType.XPCMD && !UseXpCommandOnce) || keyUp;
+            simCommand.IsUp = (!keyUp && CommandType == SimCommandType.XPCMD && UseXpCommandOnce) || keyUp;
             if (SimCommand.CommandTypeUsesDelay(CommandType, DoNotRequestBvar) && UseCommandDelay)
             {
                 simCommand.CommandDelay = CommandDelay;


### PR DESCRIPTION
(I inadverently neglected to add these changes to #151, so submitting
them again as a separate PR.)

For "Command Once" commands, this was erroneously not being set to true,
and as a result, these commands did not work correctly with the Web API.

"Command Once" commands should result in a Web API
[`command_set_is_active`](https://developer.x-plane.com/article/x-plane-web-api/#Activate_a_command_v2)
message with a duration of zero, so that the command is set and
immediately unset. To send a zero duration, `SimCommand.IsUp` should
be true (see corresponding code in
[`ConnectionManagerRest.SendCommandRef`](https://github.com/Fragtality/PilotsDeck/blob/4b8aee4aab8a3a0483936c720f9c0185cd7820f6/Plugin/Simulator/XP/ConnectionManagerREST.cs#L354).

However, `SimCommand.IsUp` was erroneously being set to false for
"Command Once" commands, and this resulted in the
`command_set_is_active` request being sent with a null duration.
This resulted in the command remaining active indefinitely. The
command would therefore only have an effect the first time, and
subsequent attempts to send the command would have no effect.

Details on the change:

*   The existing `keyUp!` looks as if it was a typo for `!keyUp`:
    Firstly, `keyUp` is not nullable, so it's not necessary to use
    the null-forgiving operator. Secondly, the case where `keyUp` is
    true is already handled anyway by the `... || keyUp` case. What
    we want to do here instead is to test for `!keyUp`. In other
    words, even if this was not a key-up event, we want to set
    `SimCommand.IsUp` to true.

*   The existing `!UseXpCommandOnce` had an extraneous `!`. We want
    to set `IsUp` to true for "Command Once" commands, so we should
    simply be testing for `UseXpCommandOnce`.
