### PR TITLE
feat: support HotSpot StreamDock Knob controllers

### DIFF
--- a/Plugin/Actions/ActionManager.cs
+++ b/Plugin/Actions/ActionManager.cs
@@ -260,7 +260,7 @@ namespace PilotsDeck.Actions
                     {
                         Redraws++;
                         Logger.Verbose($"--REDRAW-- for State '{state}' - Needs Redraw, Refresh ({action.Value.NeedRedraw}, {action.Value.NeedRefresh}) ID {action.Value.ActionID}");
-                        if (action.Value.IsEncoder)
+                        if (action.Value.IsEncoder && action.Value.CanvasInfo.UsesFeedbackLayout)
                         {
                             _ = DeckController.SetFeedbackItemImageRaw(AppConfiguration.SdTargetImage, action.Key, SelectImage(action.Value, state));
                             if (action.Value.FirstLoad)

--- a/Plugin/Actions/Advanced/ActionMeta.cs
+++ b/Plugin/Actions/Advanced/ActionMeta.cs
@@ -76,7 +76,7 @@ namespace PilotsDeck.Actions.Advanced
         public ActionMeta(StreamDeckEvent sdEvent)
         {
             Context = sdEvent.context;
-            IsEncoder = string.Equals(sdEvent?.payload?.controller, AppConfiguration.SdEncoder, StringComparison.InvariantCultureIgnoreCase);
+            IsEncoder = AppConfiguration.IsControllerEncoder(sdEvent?.payload?.controller);
             CanvasInfo = StreamDeckCanvasInfo.GetInfo(sdEvent);
             CanvasSize = CanvasInfo.GetCanvasSize();
             SetSettingModel(sdEvent);

--- a/Plugin/Actions/Simple/ActionBaseSimple.cs
+++ b/Plugin/Actions/Simple/ActionBaseSimple.cs
@@ -38,7 +38,7 @@ namespace PilotsDeck.Actions.Simple
         public ActionBaseSimple(StreamDeckEvent sdEvent)
         {
             Context = sdEvent.context;
-            IsEncoder = string.Equals(sdEvent?.payload?.controller, AppConfiguration.SdEncoder, StringComparison.InvariantCultureIgnoreCase);
+            IsEncoder = AppConfiguration.IsControllerEncoder(sdEvent?.payload?.controller);
             Settings = SettingsModelSimple.Create(sdEvent);
             CanvasInfo = StreamDeckCanvasInfo.GetInfo(sdEvent);
             CheckVersion();

--- a/Plugin/AppConfiguration.cs
+++ b/Plugin/AppConfiguration.cs
@@ -21,6 +21,22 @@ namespace PilotsDeck
         [JsonIgnore]
         public static string SdEncoder { get; } = "Encoder";
         [JsonIgnore]
+        public static string SdKnob { get; } = "Knob";
+        public static bool IsControllerEncoder(string controller)
+        {
+            if (string.IsNullOrWhiteSpace(controller))
+                return false;
+
+            return string.Equals(controller, SdEncoder, StringComparison.InvariantCultureIgnoreCase)
+                || string.Equals(controller, SdKnob, StringComparison.InvariantCultureIgnoreCase);
+        }
+        // true only for real Stream Deck+ "Encoder" controllers, which render via a layout + setFeedback.
+        // "Knob" controllers (e.g. StreamDock) do not support layout feedback and must use setImage.
+        public static bool IsControllerFeedbackEncoder(string controller)
+        {
+            return string.Equals(controller, SdEncoder, StringComparison.InvariantCultureIgnoreCase);
+        }
+        [JsonIgnore]
         public static string SdTargetImage { get; } = "canvas";
         [JsonIgnore]
         public static string SdEncoderBackground { get; } = "Plugin/Images/Encoder.png";

--- a/Plugin/StreamDeck/StreamDeckCanvasInfo.cs
+++ b/Plugin/StreamDeck/StreamDeckCanvasInfo.cs
@@ -10,6 +10,9 @@ namespace PilotsDeck.StreamDeck
         public static DeckController DeckController { get { return App.DeckController; } }
         public StreamDeckType Type { get; set; }
         public bool IsEncoder { get; set; }
+        // True for real Stream Deck+ Encoders that render through a layout + setFeedback.
+        // False for Knob controllers (e.g. StreamDock), which must use setImage instead.
+        public bool UsesFeedbackLayout { get; set; } = false;
 
         public PointF GetCanvasSize()
         {
@@ -45,7 +48,8 @@ namespace PilotsDeck.StreamDeck
         {
             StreamDeckCanvasInfo info = new()
             {
-                IsEncoder = string.Equals(sdEvent?.payload?.controller, AppConfiguration.SdEncoder, StringComparison.InvariantCultureIgnoreCase),
+                IsEncoder = AppConfiguration.IsControllerEncoder(sdEvent?.payload?.controller),
+                UsesFeedbackLayout = AppConfiguration.IsControllerFeedbackEncoder(sdEvent?.payload?.controller),
                 Type = DeckController.GetDeckType(sdEvent?.device),
             };
 

--- a/Plugin/manifest.json
+++ b/Plugin/manifest.json
@@ -11,10 +11,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -33,10 +30,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -70,10 +64,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -92,10 +83,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -114,10 +102,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -136,10 +121,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },
@@ -173,10 +155,7 @@
           "FontSize": 10
         }
       ],
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
+      "Controllers": ["Keypad", "Encoder", "Knob"],
       "Encoder": {
         "layout": "Plugin/layout-pilotsdeck.json"
       },


### PR DESCRIPTION
Add support for `Knob` controllers, such as StreamDock and HotSpot devices, alongside the existing Stream Deck+ `Encoder` controller.
Fixes https://github.com/Fragtality/PilotsDeck/issues/157
Both controller types require encoder-style rendering, including the 200×100 canvas and dial/touch commands, but they deliver images to the host differently:

* Stream Deck+ `Encoder` uses a layout and `setFeedback` through the `canvas` pixmap item defined in `layout-pilotsdeck.json`.
* `Knob` controllers do not implement the layout feedback mechanism and must receive the full rendered image through `setImage`.

Changes:

* `AppConfiguration`

  * Add the `Knob` controller constant.
  * Add `IsControllerEncoder()`, which returns `true` for both `Encoder` and `Knob`.
  * Add `IsControllerFeedbackEncoder()`, which returns `true` only for `Encoder` controllers using the layout feedback path.

* `StreamDeckCanvasInfo`

  * Add the `UsesFeedbackLayout` flag.
  * Populate it in `GetInfo()` using `IsControllerFeedbackEncoder()`.

* `ActionBaseSimple` / `ActionMeta`

  * Derive `IsEncoder` from `IsControllerEncoder()` so Knob devices use the encoder canvas and command pipeline.

* `ActionManager.Redraw`

  * Use the `setFeedback` layout branch only when `IsEncoder && UsesFeedbackLayout`.
  * Send the rendered image through `setImage` for keypad and Knob controllers.

* `manifest.json`

  * Add `Knob` to the `Controllers` list for the seven actions that already support `Encoder`.
  * Normalize the trailing newline.
